### PR TITLE
Quote the shift units in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ Shift:
 
 ```
 // move all subs 5 seconds later
-srt.shift(5, seconds);
+srt.shift(5, "seconds");
 
 // move all subs 2 seconds earlier
-srt.shift(-2, seconds);
+srt.shift(-2, "seconds");
 ```
 
 Get subtitle text:


### PR DESCRIPTION
Obviously there's not going to be a variable for seconds, and I checked the function, and it does want a string just like everyone would guess. I just figured the quotes would be good to add to the doc.